### PR TITLE
Use logger from MPRIS config instead of always printing to stdout.

### DIFF
--- a/src/DBus/Mpris/Properties.hs
+++ b/src/DBus/Mpris/Properties.hs
@@ -30,8 +30,8 @@ getProperty :: IsVariant a =>
 getProperty interface prop bus = do
   reply <- call $ getPropertyCall interface prop `to` bus
   case reply of
-    Left e   -> liftIO $ print e >> return Nothing
-    Right (Left e) -> liftIO $ print e >> return Nothing
+    Left e   -> logMessage e >> return Nothing
+    Right (Left e) -> logMessage e >> return Nothing
     Right (Right r) -> do
       let body = methodReturnBody r
       -- the bind here runs inside Maybe monad, neat!


### PR DESCRIPTION
This commit adds a `logger` field to the `Config` type, allowing the user to decide what happens to diagnostic messages printed by the library (as well as log messages to this logger themselves).

Previously, log messages were unconditionally printed to `stdout`, which is problematic for text-based applications. This is still the default behavior, but the user can now override it.
